### PR TITLE
ci: add .NET CI workflow for main branch

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -53,5 +53,24 @@ reviews:
         - Verify that `Store` and `Infrastructure` dependencies are injected via interfaces defined in `Core`.
         - Check for proper error handling and logging standards.
 
+    - path: "**/*.{yaml,yml}"
+      instructions: |
+        Review YAML files for best practices, consistency, and security.
+
+        GitHub Actions Workflows (.github/workflows/**/*.yml):
+        - **Action Versioning**: Ensure all actions use pinned versions or semantic versioning tags (e.g., `actions/checkout@v4`).
+        - **Security**: 
+          - Check for secure secret management; ensure secrets are not printed or exposed.
+          - Verify `run` commands are secure and avoid script injection vulnerabilities.
+          - Ensure least privilege permissions are set for `GITHUB_TOKEN` where applicable.
+        - **Structure**:
+          - Ensure job names and step names are descriptive.
+          - Verify `on` triggers are appropriate for the workflow.
+
+        General YAML:
+        - **Formatting**: Enforce consistent 2-space indentation.
+        - **Syntax**: specific keys should be quoted if they contain special characters.
+        - **Readability**: Ensure logical grouping of keys and comments where necessary.
+
 chat:
   auto_reply: true

--- a/.github/workflows/ci-dotnet-v1.yml
+++ b/.github/workflows/ci-dotnet-v1.yml
@@ -1,0 +1,37 @@
+name: .NET CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+        include-prerelease: true
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore
+
+    - name: Test
+      run: dotnet test --no-build --verbosity normal --logger trx --results-directory "TestResults"
+
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results
+        path: TestResults


### PR DESCRIPTION
This workflow sets up a CI pipeline for .NET projects that:
- Runs on push and pull requests to main branch
- Builds and tests the project
- Uploads test results as artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review configuration for YAML files and GitHub Actions workflows with standardized guidelines.
  * Added .NET continuous integration workflow with automated testing and result artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->