### PR TITLE
fix(webapi): fix Scalar documentation Mixed Content error

### DIFF
--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -22,7 +22,7 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
     options.ForwardLimit = 1;
     options.KnownProxies.Clear();
-    options.KnownNetworks.Clear();
+    options.KnownIPNetworks.Clear();
 });
 
 var app = builder.Build();


### PR DESCRIPTION
## Description
This PR fixes the 'Failed to fetch' error in the Scalar documentation when running in Azure Container Apps.

### Changes:
- **Relative OpenAPI URLs**: Clears the `Servers` list to force the browser to use the current origin.
- **Forwarded Headers**: Adds `UseForwardedHeaders` to correctly handle HTTPS behind the ACA ingress.
- **CORS Support**: Adds `UseCors` to allow cross-origin requests from the documentation UI.
- **Clean up**: Removes deprecated `.WithOpenApi()` call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Configuration**
  * Added CORS support and forwarded-headers handling for proxy/load-balancer environments
  * Adjusted API documentation to remove server entries and make dev docs explicit

* **Developer Experience**
  * Added a development-only test-user/authentication simulator for local testing

* **API Behavior**
  * Reduced automatic OpenAPI exposure for one endpoint to simplify its public documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->