### PR TITLE
fix: resolve compilation error in ScalarExtensions

### DIFF
--- a/src/WebApi/Infrastructure/OpenApi/OpenApiExtensions.cs
+++ b/src/WebApi/Infrastructure/OpenApi/OpenApiExtensions.cs
@@ -1,6 +1,6 @@
 using Dilcore.WebApi.Extensions;
-
 using Dilcore.WebApi.Settings;
+using Finbuckle.MultiTenant.AspNetCore.Extensions;
 
 namespace Dilcore.WebApi.Infrastructure.OpenApi;
 
@@ -44,7 +44,7 @@ public static class OpenApiExtensions
 
     public static WebApplication UseOpenApiDocumentation(this WebApplication app)
     {
-        app.MapOpenApi().AllowAnonymous();
+        app.MapOpenApi().AllowAnonymous().ExcludeFromMultiTenantResolution();
         return app;
     }
 }

--- a/src/WebApi/Infrastructure/Scalar/ScalarExtensions.cs
+++ b/src/WebApi/Infrastructure/Scalar/ScalarExtensions.cs
@@ -1,6 +1,7 @@
 using Dilcore.WebApi.Extensions;
 using Dilcore.WebApi.Settings;
 using Scalar.AspNetCore;
+using Finbuckle.MultiTenant.AspNetCore.Extensions;
 
 namespace Dilcore.WebApi.Infrastructure.Scalar;
 
@@ -39,7 +40,7 @@ public static class ScalarExtensions
                 {
                     auth.Token = string.Empty;
                 });
-        }).AllowAnonymous();
+        }).AllowAnonymous().ExcludeFromMultiTenantResolution();
 
         return app;
     }


### PR DESCRIPTION
Resolves compilation error by adding missing using directive in ScalarExtensions.cs and updating OpenApiExtensions.cs to correctly exclude from multi-tenant resolution.