### PR TITLE
Refactor Orleans Config, Fix Tests & Expose Ports

### DIFF
--- a/src/WebApi/Dockerfile
+++ b/src/WebApi/Dockerfile
@@ -3,6 +3,8 @@ USER app
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
+EXPOSE 11111
+EXPOSE 30000
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release

--- a/src/WebApi/Settings/GrainsSettings.cs
+++ b/src/WebApi/Settings/GrainsSettings.cs
@@ -6,12 +6,6 @@ namespace Dilcore.WebApi.Settings;
 public class GrainsSettings
 {
     /// <summary>
-    /// Whether to use Azure Storage clustering. 
-    /// Set to false for local development or testing with localhost clustering.
-    /// </summary>
-    public bool UseAzureClustering { get; set; } = true;
-
-    /// <summary>
     /// Azure Storage account name for clustering.
     /// The connection is established via Managed Identity.
     /// </summary>

--- a/src/WebApi/appsettings.Testing.json
+++ b/src/WebApi/appsettings.Testing.json
@@ -20,6 +20,6 @@
         }
     },
     "GrainsSettings": {
-        "StorageAccountName": "grainsettingsteststorage"
+        "StorageAccountName": ""
     }
 }

--- a/tests/WebApi/WebApi.IntegrationTests/Infrastructure/CustomWebApplicationFactory.cs
+++ b/tests/WebApi/WebApi.IntegrationTests/Infrastructure/CustomWebApplicationFactory.cs
@@ -13,24 +13,25 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 
     protected override IHost CreateHost(IHostBuilder builder)
     {
-        // Configure settings BEFORE Program.cs runs via environment variables
-        // This ensures Orleans reads our test configuration
-        builder.ConfigureHostConfiguration(config =>
-        {
-            config.AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["GrainsSettings:UseAzureClustering"] = "false",
-                ["GrainsSettings:ClusterId"] = "test-cluster",
-                ["GrainsSettings:ServiceId"] = "test-service"
-            });
-        });
-
+        // No host configuration override needed here as we use ConfigureAppConfiguration
         return base.CreateHost(builder);
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            // Add test configuration that overrides appsettings.Testing.json
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["GrainsSettings:ClusterId"] = "test-cluster",
+                ["GrainsSettings:ServiceId"] = "test-service",
+                ["GrainsSettings:StorageAccountName"] = "", // Force empty to disable Azure Clustering
+                ["AppConfigEndpoint"] = "" // Disable Azure App Configuration in tests
+            });
+        });
 
         builder.ConfigureServices(services =>
         {


### PR DESCRIPTION
## Changes
- **Refactoring**: specific removal of `UseAzureClustering` flag in favor of checking `StorageAccountName`.
- **Integration Tests**: Fixed failing tests by explicitly disabling Azure App Configuration and Azure Storage connections in `CustomWebApplicationFactory` and `appsettings.Testing.json`.
- **Networking**: Exposed Orleans ports `11111` and `30000` in `Dockerfile` and configured them in `Program.cs` to ensure proper container networking.
- **Reliability**: Improved test reliability and performance (~6.5s execution time for integration tests).

## Verification
- `dotnet test` passed 122/122 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application port configuration with two additional exposed ports (11111, 30000)
  * Simplified clustering configuration logic; Azure clustering now determined by storage account settings rather than separate configuration flag
  * Refactored test configuration to use in-memory settings override approach

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->